### PR TITLE
Upgrade ttypescript version to 1.5.15

### DIFF
--- a/source/packages/@ada/cdk-core/package.json
+++ b/source/packages/@ada/cdk-core/package.json
@@ -25,6 +25,6 @@
     "cross-env": "^7.0.2",
     "module-alias": "^2.2.2",
     "string-hash": "^1.1.3",
-    "ttypescript": "^1.5.12"
+    "ttypescript": "1.5.15"
   }
 }

--- a/source/packages/@ada/infra/package.json
+++ b/source/packages/@ada/infra/package.json
@@ -119,6 +119,6 @@
     "promptly": "^3.2.0",
     "string-hash": "^1.1.3",
     "tsconfig-paths": "^4.1.0",
-    "ttypescript": "^1.5.12"
+    "ttypescript": "1.5.15"
   }
 }

--- a/source/packages/@ada/transforms/package.json
+++ b/source/packages/@ada/transforms/package.json
@@ -21,6 +21,6 @@
   "devDependencies": {
     "@rjsf/core": "^4.2.0",
     "@types/json-schema": "^7.0.9",
-    "ttypescript": "^1.5.12"
+    "ttypescript": "1.5.15"
   }
 }


### PR DESCRIPTION
This PR fixes Issue: #58 
There is bug is ttypescript where we ends up getting "Cannot set property constructor of [object Object] which has only a getter"
at
```
/mnt/d/workspace/pocs/automated-data-analytics-on-aws/source/node_modules/ttypescript/lib/loadTypescript.js:13
        function __() { this.constructor = d; }
```

This bug is raised on ttypescript repository with solution to upgrade version to 1.5.15
#https://github.com/cevek/ttypescript/issues/150

So upgraded ttypescript version to 1.5.15